### PR TITLE
Second round of improvements for hygdrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,8 @@ TODO
 - [x] Code can not handle referencing function defined in the same line
 - [x] Write a new driver and remove `hygdrop/__init__.hy`
 - [x] Integrate spy mode to dump python code
-- [ ] Define DSL to add misc functionalities to bot
- 
+- [ ] Pastebin the looong lines and give the pastebin link to IRC
+- [ ] Move second level exception messages from stderr to IRC
+- [ ] Port command.clj from [Cjoey](https://github.com/Foxboron/Parjer/blob/master/src/parjer/commands.clj)
+      to command.hy
+- [ ] Improve message handling by bot

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ TODO
 - [x] Code can not handle referencing function defined in the same line
 - [x] Write a new driver and remove `hygdrop/__init__.hy`
 - [x] Integrate spy mode to dump python code
-- [ ] Pastebin the looong lines and give the pastebin link to IRC
-- [ ] Move second level exception messages from stderr to IRC
+- [x] Pastebin the looong lines and give the pastebin link to IRC
+- [x] Move second level exception messages from stderr to IRC
 - [ ] Port command.clj from [Cjoey](https://github.com/Foxboron/Parjer/blob/master/src/parjer/commands.clj)
       to command.hy
-- [ ] Improve message handling by bot
+- [ ] Implement private message handling by bot

--- a/hygdrop.hy
+++ b/hygdrop.hy
@@ -23,21 +23,21 @@ Options:
 (def *arguments* (kwapply (docopt *usage*) {"version" "Hygdrop 0.1"}))
 
 (defun welcome-handler [connection event]
-  (foreach [(, dir subdir files) (os.walk (-> (os.path.dirname
+  (for [(, dir subdir files) (os.walk (-> (os.path.dirname
 					       (os.path.realpath __file__))
 					      (os.path.join "plugins")))]
-    (foreach [file files]
+    (for [file files]
       (if (.endswith file ".hy")
 	(.append *plugins* (import_file_to_module (get (.split file ".") 0)
 						  (os.path.join dir file))))))
   (if (get *arguments* "--channel")
-    (foreach [channel (.split (get *arguments* "--channel") ",")]
+    (for [channel (.split (get *arguments* "--channel") ",")]
       (.join connection channel))
     (.join connection "#hy")))
 
 (defun pubmsg-handler [connection event]
   (let [[arg (get event.arguments 0)]]
-    (foreach [plugin *plugins*]
+    (for [plugin *plugins*]
       (.process plugin connection event arg))))
 
 (defun start[]

--- a/plugins/codeeval.hy
+++ b/plugins/codeeval.hy
@@ -2,6 +2,7 @@
 	sys
 	builtins
 	astor
+	requests
 	[io [StringIO]]
 	[time [sleep]]
 	[hy.importer [import_buffer_to_hst ast_compile]]
@@ -10,17 +11,32 @@
 
 (def *hr* (HyREPL))
 
+(defmacro paste-code [payload &rest body]
+  `(let [[r (kwapply (.post requests "https://www.refheap.com/api/paste")
+		     {"data" ~payload})]] ~@body))
+
 (defn dump-exception [e]
   (.write sys.stderr (str e))
   (.write sys.stderr "\n")
   (.flush sys.stderr))
+
+
 
 (defun eval-code [connection target code &optional [dry-run False]]
   (setv sys.stdout (StringIO))
   (.runsource *hr* code)
   (if dry-run
     (.replace (.getvalue sys.stdout) "\n" " ")
-    (.privmsg connection target (.replace (.getvalue sys.stdout) "\n" " "))))
+    (let [[output (.getvalue sys.stdout)]
+	  [message ["Hey output was too long I pasted it at"]]]
+      (if (!= (.find output "\n") -1)
+	(paste-code {"content" output "language" "Clojure"}
+		    (if (= r.status_code 201)
+		      (progn
+		       (setv do-not-return-damnit
+			     (.append message (get (.json r) "url")))
+		       (.privmsg connection target (.join " " message))))))
+      (.privmsg connection target (.replace output "\n" " ")))))
 
 (defun source-code [connection target hy-code &optional [dry-run False]]
   (let [[astorcode (-> (import_buffer_to_hst hy-code)
@@ -28,7 +44,7 @@
 	[pysource (.to_source astor.codegen astorcode)]]
     (if dry-run
       pysource
-      (foreach [line (.split pysource "\n")]
+      (for [line (.split pysource "\n")]
 	(.privmsg connection target line)
 	(sleep 0.5)))))
 
@@ -46,7 +62,7 @@
 						  (+ (len "!source") 1)))))
    (catch [e Exception]
      (try
-      (foreach [line (.split (str e) "\n")]
+      (for [line (.split (str e) "\n")]
 	(.notice connection event.target line)
 	(sleep 0.5))
       (catch [f Exception]

--- a/plugins/codeeval.hy
+++ b/plugins/codeeval.hy
@@ -1,81 +1,151 @@
 (import ast
-	sys
-	builtins
-	astor
-	requests
-	[io [StringIO]]
-	[time [sleep]]
-	[hy.importer [import_buffer_to_hst ast_compile]]
-	[hy.compiler [hy_compile]]
-	[hy.cmdline [HyREPL]])
+        sys
+        builtins
+        astor
+        requests
+        code
+        traceback
+        [io [StringIO]]
+        [time [sleep]]
+        [hy.lex [LexException PrematureEndOfInput tokenize]]
+        [hy.importer [import_buffer_to_hst ast_compile]]
+        [hy.compiler [hy_compile HyTypeError]])
 
-(def *hr* (HyREPL))
+
+(defclass HygdropREPL [code.InteractiveConsole]
+  "Hygdrops REPL - Class is a REPL to execute the code for Hygdrop,
+  this class doesn't strictly adhere to REPL rules and raises
+  exception so it can be communicated to end user."
+  [[--init--
+    (fn [self &optional [locals null] [filename "<input"]]
+      (kwapply (code.InteractiveConsole.__init__ self)
+               {"locals" locals "filename" filename}))]
+   [runsource
+    (fn [self source &optional [filename "<input>"] [symbol "single"]]
+      (try
+       (setv tokens (tokenize source))
+       (catch [p PrematureEndOfInput]
+         (progn
+          (.setexception-source self p source filename)
+          (raise p)))
+       (catch [l LexException]
+         (progn
+          (.setexception-source self l source filename)
+          (raise l))))
+      (try
+       (progn
+        (setv -ast (hy_compile tokens "__console__" ast.Interactive))
+        (setv code (ast_compile -ast filename symbol)))
+       (catch [ht HyTypeError]
+         (progn
+          (.setexception-source self ht source filename)
+          (raise ht)))
+       (catch [e Exception]
+         (raise e)))
+      (.runcode self code)
+      False)]
+   [setexception-source
+    (fn [self e source filename]
+      "When exceptions are raised if e.source is not set then set it to
+  current source otherwise the code will break at __str__
+  function. This functions are called only for Hy specific  exceptions"
+      (if (= e.source None)
+        (setv e.source source)
+        (setv e.filename filename)))]])
+
+(def *hr* (HygdropREPL))
 
 (defmacro paste-code [payload &rest body]
   `(let [[r (.post requests "https://www.refheap.com/api/paste" ~payload)]]
      ~@body))
 
-(defn dump-exception [connection target e]
+(defun dump-exception [connection target e]
   (paste-code {"contents" (str e) "language" "Python Traceback"}
-	      (if (= r.status_code 201)
-		(.privmsg connection target
-			  (.format "Aargh something broke {}"
-				   (get (.json r) "url")))
-		(progn
-		 (.write sys.stderr (str e))
-		 (.write sys.stderr "\n")
-		 (.flush sys.stderr)))))
+              (if (= r.status_code 201)
+                (.privmsg connection target
+                          (.format "Aargh something broke, traceback: {}"
+                                   (get (.json r) "url")))
+                (progn
+                 (.write sys.stderr (str e))
+                 (.write sys.stderr "\n")
+                 (.flush sys.stderr)))))
+
+(defun dump-traceback [connection target]
+  (let [[tblist (.extract_tb traceback sys.last_traceback)]
+        [lines (.format_list traceback (cdr tblist))]]
+    (if lines
+      (.insert lines 0 "Traceback (most recent call last):\n"))
+    (.extend lines (.format_exception_only traceback sys.last_type
+                                           sys.last_value))
+    (paste-code {"contents" (.join "" lines) "language" "Python Traceback"}
+                (if (= r.status_code 201)
+                  (.privmsg connection target
+                            (.format "Aargh something broke, traceback {}"
+                                     (get (.json r) "url")))
+                  (for [line (.split lines "\n")]
+                    (.privmsg connection target line)
+                    (sleep 0.5))))
+    ;; Cleanup the sys attributes so that we can recognize next error,
+    ;; if not cleared this will get always executed that is IIUC.
+    (delattr sys "last_value")
+    (delattr sys "last_type")
+    (delattr sys "last_traceback")
+    (setv tblist null)))
 
 (defun eval-code [connection target code &optional [dry-run False]]
   (setv sys.stdout (StringIO))
   (.runsource *hr* code)
   ;; (exec (ast_compile (-> (import_buffer_to_hst code)
-  ;; 				  (hy_compile "__main__" ast.Interactive))
-  ;; 			      "<input>" "single"))
+  ;;                              (hy_compile "__main__" ast.Interactive))
+  ;;                          "<input>" "single"))
   (if dry-run
     (.replace (.getvalue sys.stdout) "\n" " ")
     (let [[output (.getvalue sys.stdout)]
-	  [message ["Output was too long bro, so here is the paste:"]]]
+          [message ["Output was too long bro, so here is the paste:"]]]
       (if (>= (len output) 512)
-	(paste-code {"contents" output "language" "IRC Logs"}
-		    (if (= r.status_code 201)
-		      (progn
-		       (.append message (get (.json r) "url"))
-		       (.privmsg connection target (.join " " message)))))
-	(.privmsg connection target (.replace output "\n" " "))))))
+        (paste-code {"contents" output "language" "IRC Logs"}
+                    (if (= r.status_code 201)
+                      (progn
+                       (.append message (get (.json r) "url"))
+                       (.privmsg connection target (.join " " message)))))
+        (.privmsg connection target (.replace output "\n" " "))))))
 
 (defun source-code [connection target hy-code &optional [dry-run False]]
   (let [[astorcode (-> (import_buffer_to_hst hy-code)
-		       (hy_compile __name__ ))]
-	[pysource (.to_source astor.codegen astorcode)]]
+                       (hy_compile __name__ ))]
+        [pysource (.to_source astor.codegen astorcode)]]
     (if dry-run
       pysource
       (paste-code {"contents" pysource "language" "Python"}
-		  (if (= r.status_code 201)
-		    (.privmsg connection target
-			      (.format "Yo bro your source is ready at {}"
-				       (get (.json r) "url")))
-		    (.privmsg connection target
-			      "Something went wrong while creating paste"))))))
+                  (if (= r.status_code 201)
+                    (.privmsg connection target
+                              (.format "Yo bro your source is ready at {}"
+                                       (get (.json r) "url")))
+                    (.privmsg connection target
+                              "Something went wrong while creating paste"))))))
 
 (defun process [connection event message]
   (try
    (progn
     (if (or (.startswith message ",")
-	    (.startswith message (+ connection.nickname ": ")))
+            (.startswith message (+ connection.nickname ": ")))
       (progn
        (setv code-startpos ((fn[] (if (.startswith message ",") 1
-				      (+ (len connection.nickname) 1)))))
-       (eval-code connection event.target (slice message code-startpos))))
+                                      (+ (len connection.nickname) 1)))))
+       (eval-code connection event.target (slice message code-startpos))
+       ;; check if an error occured and is printed by show_traceback
+       ;; of REPL to stderr in that case print this traceback to IRC
+       (if (hasattr sys "last_traceback")
+         (dump-traceback connection event.target))))
     (if (.startswith message "!source")
       (source-code connection event.target (slice message
-						  (+ (len "!source") 1)))))
+                                                  (+ (len "!source") 1)))))
    (catch [e Exception]
      (try
       (for [line (.split (str e) "\n")]
-	(.notice connection event.target line)
-	(sleep 0.5))
+        (.privmsg connection event.target line)
+        (sleep 0.5))
       (catch [f Exception]
-	(progn
-	 (dump-exception connection event.target e)
-	 (dump-exception connection event.target f)))))))
+        (progn
+         (dump-exception connection event.target e)
+         (dump-exception connection event.target f)))))))

--- a/plugins/codeeval.hy
+++ b/plugins/codeeval.hy
@@ -116,13 +116,17 @@
         [pysource (.to_source astor.codegen astorcode)]]
     (if dry-run
       pysource
-      (paste-code {"contents" pysource "language" "Python"}
-                  (if (= r.status_code 201)
-                    (.privmsg connection target
-                              (.format "Yo bro your source is ready at {}"
-                                       (get (.json r) "url")))
-                    (.privmsg connection target
-                              "Something went wrong while creating paste"))))))
+      (if (or (!= (.find pysource "\n") -1) (>= (len pysource) 512))
+        (paste-code {"contents" pysource "language" "Python"}
+                    (if (= r.status_code 201)
+                      (.privmsg connection target
+                                (.format "Yo bro your source is ready at {}"
+                                         (get (.json r) "url")))
+                      (.privmsg connection target
+                                "Something went wrong while creating paste")))
+        (for [srcline (.split pysource "\n")]
+          (.privmsg connection target srcline)
+          (sleep 0.5))))))
 
 (defun process [connection event message]
   (try

--- a/plugins/codeeval.hy
+++ b/plugins/codeeval.hy
@@ -102,7 +102,7 @@
     (.replace (.getvalue sys.stdout) "\n" " ")
     (let [[output (.getvalue sys.stdout)]
           [message ["Output was too long bro, so here is the paste:"]]]
-      (if (>= (len output) 512)
+      (if (or (>= (len output) 512) (!= (.find output "\n") -1))
         (paste-code {"contents" output "language" "IRC Logs"}
                     (if (= r.status_code 201)
                       (progn

--- a/plugins/github.hy
+++ b/plugins/github.hy
@@ -65,7 +65,7 @@
 	  [message (list)]]
       (if (= (getattr api-result "status_code") 200)
 	(do
-	 (foreach [dev api-json]
+	 (for [dev api-json]
 	   (do
 	    (setv dev-result (.get requests
 				   (.format "https://api.github.com/users/{}"

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -14,7 +14,7 @@ def test_get_github_issue():
         ["Issue #" + "180", "on", "hylang/hy", "by",
          "khinsen:",
          "Macro expansion works differently from Lisp conventions",
-         "(open)",
+         "(open)", "[bug]",
          "<https://github.com/hylang/hy/issues/180>"])
     actual = g.get_github_issue(None, None, "180", dry_run=True)
     assert expected == actual

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -37,7 +37,7 @@ def test_get_core_members():
                           "Gergely Nagy", "Berker Peksag",
                           "Christopher Allan Webber", "khinsen",
                           "J Kenneth King", "Paul Tagliamonte",
-                          "Will Kahn-Greene", "Morten Linderud",
-                          "Abhishek L"])
+                          "Bob Tolbert", "Will Kahn-Greene",
+                          "Morten Linderud", "Abhishek L"])
     actual = g.get_core_members(None, None, dry_run=True)
     assert actual == expected

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -10,10 +10,13 @@ g = import_file_to_module("github", plugin_to_load)
 
 
 def test_get_github_issue():
-    expected = " ".join(["Pull Request #" + "310", "on", "hylang/hy", "by",
-                         "sbp:", "Library based macroexpand and macroexpand-1",
-                         "(open)", "<https://github.com/hylang/hy/pull/310>"])
-    actual = g.get_github_issue(None, None, "310", dry_run=True)
+    expected = " ".join(
+        ["Issue #" + "180", "on", "hylang/hy", "by",
+         "khinsen:",
+         "Macro expansion works differently from Lisp conventions",
+         "(open)",
+         "<https://github.com/hylang/hy/issues/180>"])
+    actual = g.get_github_issue(None, None, "180", dry_run=True)
     assert expected == actual
 
 


### PR DESCRIPTION
Following things are done in this PR
- Port hygdrop for 0.9.12, replace `foreach` with `for`
- Handle broken test cases which are related to network
- Implement HygdropREPL with specific customization for the bot
- Better error handling in code execution and exception/traceback tracking.
- Long and multiline output/source and exceptions are pasted to refheap.com and URL is pasted to IRC.

Probably the _bro_ messages by hygdrop can be improved if needed.
